### PR TITLE
fix: click event does not respond when disable the event bubbling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: report
-          files: coverage/clover.xml
+          files: coverage/coverage-final.json

--- a/test/tracker/ClickTracker.test.ts
+++ b/test/tracker/ClickTracker.test.ts
@@ -65,7 +65,7 @@ describe('ClickTracker test', () => {
 		clickTracker.setUp();
 		window.document.dispatchEvent(new window.Event('click'));
 		expect(recordMethodMock).not.toBeCalled();
-		expect(trackClickMock).toBeCalled();
+		expect(trackClickMock).not.toBeCalled();
 	});
 
 	test('test click a element with current domain', () => {
@@ -87,6 +87,19 @@ describe('ClickTracker test', () => {
 				[Event.ReservedAttribute.OUTBOUND]: false,
 			},
 		});
+	});
+
+	test('test disable the configuration for track click event', () => {
+		provider.configuration.isTrackClickEvents = false;
+		const clickEvent = getMockMouseEvent(
+			'A',
+			'https://localhost/collect',
+			'link-class',
+			'link-id'
+		);
+		clickTracker.setUp();
+		clickTracker.trackClick(clickEvent);
+		expect(recordMethodMock).not.toBeCalled();
 	});
 
 	test('test click a element in configured domain', () => {
@@ -174,6 +187,28 @@ describe('ClickTracker test', () => {
 		});
 	});
 
+	test('test click a element with out a tag in parent', () => {
+		const clickEvent = getMockMouseEvent('SPAN', '', '', '');
+		const targetElement = document.createElement('SPAN');
+		Object.defineProperty(clickEvent.target, 'parentElement', {
+			writable: true,
+			value: targetElement,
+		});
+		clickTracker.setUp();
+		clickTracker.trackClick(clickEvent);
+		expect(recordMethodMock).not.toBeCalled();
+	});
+
+	test('test add A tag and trigger MutationObserver', async () => {
+		clickTracker.setUp();
+		const div = document.createElement('div');
+		const aTag = document.createElement('A');
+		div.appendChild(aTag);
+		document.body.appendChild(div);
+		await sleep(100);
+		expect(clickTracker.processedElements.has(aTag)).toBeTruthy();
+	});
+
 	function getMockMouseEvent(
 		tagName: string,
 		href: string,
@@ -190,5 +225,9 @@ describe('ClickTracker test', () => {
 			value: targetElement,
 		});
 		return event;
+	}
+
+	function sleep(ms: number): Promise<void> {
+		return new Promise(resolve => setTimeout(resolve, ms));
 	}
 });


### PR DESCRIPTION
## Description
1. fix click on the A label event does not respond when the event is prevented from bubbling

## General Checklist

- [x] Added new tests to cover change, if needed
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
