### PR TITLE
fix: change user engagement event and engagement time calculate rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ ClickstreamAnalytics.configure({
    sendMode: EventMode.Batch,
    sendEventsInterval: 5000,
    isTrackPageViewEvents: true,
+   isTrackUserEngagementEvents: true,
    isTrackClickEvents: true,
    isTrackSearchEvents: true,
    isTrackScrollEvents: true,
@@ -132,6 +133,7 @@ Here is an explanation of each property:
 - **sendMode**: EventMode.Immediate, EventMode.Batch, default is Immediate mode.
 - **sendEventsInterval**: event sending interval millisecond, works only bath send mode, the default value is `5000`
 - **isTrackPageViewEvents**: whether auto record page view events in browser, default is `true`
+- **isTrackUserEngagementEvents**: whether auto record user engagement events in browser, default is `true`
 - **isTrackClickEvents**: whether auto record link click events in browser, default is `true`
 - **isTrackSearchEvents**: whether auto record search result page events in browser, default is `true`
 - **isTrackScrollEvents**: whether auto record page scroll events in browser, default is `true`
@@ -152,6 +154,7 @@ ClickstreamAnalytics.updateConfigure({
   isLogEvents: true,
   authCookie: 'your auth cookie',
   isTrackPageViewEvents: false,
+  isTrackUserEngagementEvents: false,
   isTrackClickEvents: false,
   isTrackScrollEvents: false,
   isTrackSearchEvents: false,

--- a/src/provider/AnalyticsEventBuilder.ts
+++ b/src/provider/AnalyticsEventBuilder.ts
@@ -24,18 +24,17 @@ import {
 	Item,
 	UserAttribute,
 } from '../types';
-import { HashUtil } from '../util/HashUtil';
 import { StorageUtil } from '../util/StorageUtil';
 
 const sdkVersion = config.sdkVersion;
 
 export class AnalyticsEventBuilder {
-	static async createEvent(
+	static createEvent(
 		context: ClickstreamContext,
 		event: ClickstreamEvent,
 		userAttributes: UserAttribute,
 		session?: Session
-	): Promise<AnalyticsEvent> {
+	): AnalyticsEvent {
 		const { browserInfo, configuration } = context;
 		const attributes = this.getEventAttributesWithCheck(event.attributes);
 		if (session !== undefined) {
@@ -56,8 +55,7 @@ export class AnalyticsEventBuilder {
 			browserInfo.latestReferrerHost;
 
 		const items = this.getEventItemsWithCheck(event.items, attributes);
-
-		const analyticEvent = {
+		return {
 			hashCode: '',
 			event_type: event.name,
 			event_id: uuidV4(),
@@ -80,10 +78,6 @@ export class AnalyticsEventBuilder {
 			user: userAttributes ?? {},
 			attributes: attributes,
 		};
-		analyticEvent.hashCode = await HashUtil.getHashCode(
-			JSON.stringify(analyticEvent)
-		);
-		return analyticEvent;
 	}
 
 	static getEventAttributesWithCheck(

--- a/src/provider/Event.ts
+++ b/src/provider/Event.ts
@@ -53,6 +53,7 @@ export class Event {
 		PAGE_REFERRER_TITLE: '_page_referrer_title',
 		LATEST_REFERRER: '_latest_referrer',
 		LATEST_REFERRER_HOST: '_latest_referrer_host',
+		PREVIOUS_TIMESTAMP: '_previous_timestamp',
 		ENTRANCES: '_entrances',
 		SESSION_ID: '_session_id',
 		SESSION_DURATION: '_session_duration',

--- a/src/types/Analytics.ts
+++ b/src/types/Analytics.ts
@@ -26,6 +26,7 @@ export interface Configuration {
 	isLogEvents?: boolean;
 	authCookie?: string;
 	isTrackPageViewEvents?: boolean;
+	isTrackUserEngagementEvents?: boolean;
 	isTrackClickEvents?: boolean;
 	isTrackScrollEvents?: boolean;
 	isTrackSearchEvents?: boolean;

--- a/src/util/StorageUtil.ts
+++ b/src/util/StorageUtil.ts
@@ -259,7 +259,7 @@ export class StorageUtil {
 	}
 
 	static getPreviousPageStartTime(): number {
-		const startTime = sessionStorage.getItem(
+		const startTime = localStorage.getItem(
 			StorageUtil.previousPageStartTimeKey
 		);
 		if (startTime === null) {
@@ -270,7 +270,7 @@ export class StorageUtil {
 	}
 
 	static savePreviousPageStartTime(timestamp: number) {
-		sessionStorage.setItem(
+		localStorage.setItem(
 			StorageUtil.previousPageStartTimeKey,
 			timestamp.toString()
 		);

--- a/test/network/NetRequest.test.ts
+++ b/test/network/NetRequest.test.ts
@@ -15,7 +15,7 @@ import { ClickstreamAnalytics } from '../../src';
 import { BrowserInfo } from '../../src/browser';
 import { NetRequest } from '../../src/network/NetRequest';
 import { AnalyticsEventBuilder, ClickstreamContext } from '../../src/provider';
-import {Session} from "../../src/tracker";
+import { Session } from '../../src/tracker';
 
 describe('ClickstreamAnalytics test', () => {
 	let context: ClickstreamContext;
@@ -25,7 +25,7 @@ describe('ClickstreamAnalytics test', () => {
 			appId: 'testApp',
 			endpoint: 'https://localhost:8080/collect',
 		});
-		const event = await AnalyticsEventBuilder.createEvent(
+		const event = AnalyticsEventBuilder.createEvent(
 			context,
 			{ name: 'testEvent' },
 			{},
@@ -82,13 +82,7 @@ describe('ClickstreamAnalytics test', () => {
 			appId: 'testApp',
 			endpoint: 'https://localhost:8080/collect',
 		});
-		const result = await NetRequest.sendRequest(
-			eventJson,
-			context,
-			1,
-			1,
-			200
-		);
+		const result = await NetRequest.sendRequest(eventJson, context, 1, 1, 200);
 		expect(result).toBeFalsy();
 	});
 });

--- a/test/provider/AnalyticsEventBuilder.test.ts
+++ b/test/provider/AnalyticsEventBuilder.test.ts
@@ -32,13 +32,13 @@ describe('AnalyticsEventBuilder test', () => {
 			appId: 'testApp',
 			endpoint: 'https://example.com/collect',
 		});
-		const event = await AnalyticsEventBuilder.createEvent(
+		const event = AnalyticsEventBuilder.createEvent(
 			context,
 			{ name: 'testEvent' },
 			{},
 			Session.getCurrentSession(context)
 		);
-		expect(event.hashCode.length).toBe(8);
+		expect(event.hashCode.length).toBe(0);
 		expect(event.event_type).toBe('testEvent');
 		expect(event.event_id.length > 0).toBeTruthy();
 		expect(event.device_id.length > 0).toBeTruthy();

--- a/test/provider/EventRecorder.test.ts
+++ b/test/provider/EventRecorder.test.ts
@@ -236,7 +236,7 @@ describe('EventRecorder test', () => {
 	async function getTestEvent(
 		eventName = 'testEvent'
 	): Promise<AnalyticsEvent> {
-		return await AnalyticsEventBuilder.createEvent(
+		return AnalyticsEventBuilder.createEvent(
 			context,
 			{ name: eventName },
 			{},

--- a/test/util/StorageUtil.test.ts
+++ b/test/util/StorageUtil.test.ts
@@ -179,7 +179,7 @@ describe('StorageUtil test', () => {
 			appId: 'testApp',
 			endpoint: 'https://example.com/collect',
 		});
-		return await AnalyticsEventBuilder.createEvent(
+		return AnalyticsEventBuilder.createEvent(
 			context,
 			{ name: eventName },
 			{},


### PR DESCRIPTION
## Description
Change the user engagement event definition to: Calculate an engagement event for each screen leave.
Changes the screen view engage time to the engage time of the previous user engagement event.
Add configuration for user engagement event.

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
