### PR TITLE
fix: change configure method to init in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ In addition to the required `appId` and `endpoint`, you can configure other info
 ```typescript
 import { ClickstreamAnalytics, EventMode, PageType } from '@aws/clickstream-web';
 
-ClickstreamAnalytics.configure({
+ClickstreamAnalytics.init({
    appId: "your appId",
    endpoint: "https://example.com/collect",
    sendMode: EventMode.Batch,


### PR DESCRIPTION
## Description
1. change the `configure()` method to `init()` in readme

## General Checklist
<!-- Check or cross out if not relevant -->

- [ ] Added new tests to cover change, if needed
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
