### PR TITLE
feat: record error event when event name is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import { ClickstreamAnalytics } from '@aws/clickstream-web';
 
 // record event with attributes
 ClickstreamAnalytics.record({
-  name: 'add_to_cart',
+  name: 'button_click',
   attributes: {
     event_category: 'shoes',
     currency: 'CNY',
@@ -74,7 +74,7 @@ ClickstreamAnalytics.setUserAttributes({
 });
 ```
 
-Current login user's attributes will be cached in localStorage, so the next time browser open you don't need to set all user's attribute again, of course you can use the same api `ClickstreamAnalytics.setUserAttributes()` to update the current user's attribute when it changes.
+When opening for the first time after integrating the SDK, you need to manually set the user attributes once, and current login user's attributes will be cached in localStorage, so the next time browser open you don't need to set all user's attribute again, of course you can use the same api `ClickstreamAnalytics.setUserAttributes()` to update the current user's attribute when it changes.
 
 #### Record event with items
 

--- a/src/provider/ClickstreamProvider.ts
+++ b/src/provider/ClickstreamProvider.ts
@@ -118,6 +118,14 @@ export class ClickstreamProvider implements AnalyticsProvider {
 	record(event: ClickstreamEvent) {
 		const result = EventChecker.checkEventName(event.name);
 		if (result.error_code > 0) {
+			const errorEvent = this.createEvent({
+				name: Event.PresetEvent.CLICKSTREAM_ERROR,
+				attributes: {
+					[Event.ReservedAttribute.ERROR_CODE]: result.error_code,
+					[Event.ReservedAttribute.ERROR_MESSAGE]: result.error_message,
+				},
+			});
+			this.recordEvent(errorEvent);
 			logger.error(result.error_message);
 			return;
 		}

--- a/test/provider/ClickstreamProvider.test.ts
+++ b/test/provider/ClickstreamProvider.test.ts
@@ -102,9 +102,13 @@ describe('ClickstreamProvider test', () => {
 	});
 
 	test('test record event with invalid event name', () => {
-		mockCreateEvent = jest.spyOn(AnalyticsEventBuilder, 'createEvent');
+		const mockProviderCreateEvent = jest.spyOn(provider, 'createEvent');
 		provider.record({ name: '01testEvent' });
-		expect(mockCreateEvent).not.toHaveBeenCalled();
+		expect(mockProviderCreateEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: Event.PresetEvent.CLICKSTREAM_ERROR,
+			})
+		);
 	});
 
 	test('test setUserAttributes reached max number limit', () => {

--- a/test/provider/ClickstreamProvider.test.ts
+++ b/test/provider/ClickstreamProvider.test.ts
@@ -104,9 +104,14 @@ describe('ClickstreamProvider test', () => {
 	test('test record event with invalid event name', () => {
 		const mockProviderCreateEvent = jest.spyOn(provider, 'createEvent');
 		provider.record({ name: '01testEvent' });
+		const { ERROR_CODE, ERROR_MESSAGE } = Event.ReservedAttribute;
 		expect(mockProviderCreateEvent).toHaveBeenCalledWith(
 			expect.objectContaining({
 				name: Event.PresetEvent.CLICKSTREAM_ERROR,
+				attributes: {
+					[ERROR_CODE]: Event.ErrorCode.EVENT_NAME_INVALID,
+					[ERROR_MESSAGE]: expect.anything(),
+				},
 			})
 		);
 	});


### PR DESCRIPTION
## Description
1. record an error event when event name is invalid

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [x] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
