### PR TITLE
fix: add user_first_touch_timestamp user attribute in _first_open event

### DIFF
--- a/src/provider/ClickstreamProvider.ts
+++ b/src/provider/ClickstreamProvider.ts
@@ -81,7 +81,7 @@ export class ClickstreamProvider implements AnalyticsProvider {
 		this.eventRecorder = new EventRecorder(this.context);
 		this.globalAttributes = {};
 		this.setGlobalAttributes(configuration.globalAttributes);
-
+		this.userAttributes = StorageUtil.getUserAttributes();
 		this.sessionTracker = new SessionTracker(this, this.context);
 		this.pageViewTracker = new PageViewTracker(this, this.context);
 		this.clickTracker = new ClickTracker(this, this.context);
@@ -90,7 +90,6 @@ export class ClickstreamProvider implements AnalyticsProvider {
 		this.pageViewTracker.setUp();
 		this.clickTracker.setUp();
 		this.scrollTracker.setUp();
-		this.userAttributes = StorageUtil.getUserAttributes();
 		if (configuration.sendMode === SendMode.Batch) {
 			this.startTimer();
 		}

--- a/test/ClickstreamAnalytics.test.ts
+++ b/test/ClickstreamAnalytics.test.ts
@@ -64,6 +64,7 @@ describe('ClickstreamAnalytics test', () => {
 		);
 		const firstEvent = eventList[0];
 		expect(firstEvent.event_type).toBe(Event.PresetEvent.FIRST_OPEN);
+		expect(firstEvent.user[Event.ReservedAttribute.USER_FIRST_TOUCH_TIMESTAMP]).not.toBeUndefined()
 		expect(firstEvent.attributes.brand).toBe('Samsung');
 		expect(firstEvent.attributes.level).toBe(10);
 		const testEvent = eventList[eventList.length - 1];


### PR DESCRIPTION
## Description
1. add `user_first_touch_timestamp` in `_first_open` event

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
