### PR TITLE
feat: delete custom user attributes from subsequent events

### DIFF
--- a/src/util/StorageUtil.ts
+++ b/src/util/StorageUtil.ts
@@ -101,7 +101,7 @@ export class StorageUtil {
 					set_timestamp: timestamp,
 				},
 				[Event.ReservedAttribute.USER_FIRST_TOUCH_TIMESTAMP]:
-					StorageUtil.getUserAttributes()[
+					StorageUtil.getAllUserAttributes()[
 						Event.ReservedAttribute.USER_FIRST_TOUCH_TIMESTAMP
 					],
 			};
@@ -149,10 +149,23 @@ export class StorageUtil {
 		);
 	}
 
-	static getUserAttributes(): UserAttribute {
+	static getAllUserAttributes(): UserAttribute {
 		const userAttributes =
 			localStorage.getItem(StorageUtil.userAttributesKey) ?? '{}';
 		return JSON.parse(userAttributes);
+	}
+
+	static getSimpleUserAttributes(): UserAttribute {
+		const allUserAttributes = StorageUtil.getAllUserAttributes();
+		const simpleUserAttributes: UserAttribute = {
+			[Event.ReservedAttribute.USER_FIRST_TOUCH_TIMESTAMP]:
+				allUserAttributes[Event.ReservedAttribute.USER_FIRST_TOUCH_TIMESTAMP],
+		};
+		if (allUserAttributes[Event.ReservedAttribute.USER_ID] !== undefined) {
+			simpleUserAttributes[Event.ReservedAttribute.USER_ID] =
+				allUserAttributes[Event.ReservedAttribute.USER_ID];
+		}
+		return simpleUserAttributes;
 	}
 
 	static getFailedEvents(): string {

--- a/test/provider/ClickstreamProvider.test.ts
+++ b/test/provider/ClickstreamProvider.test.ts
@@ -212,7 +212,7 @@ describe('ClickstreamProvider test', () => {
 		expect(
 			Event.ReservedAttribute.USER_ID in provider.userAttributes
 		).toBeFalsy();
-		expect(mockRecordProfileSet).toBeCalledTimes(1);
+		expect(mockRecordProfileSet).toBeCalledTimes(2);
 	});
 
 	test('test set userId not null', () => {
@@ -269,6 +269,23 @@ describe('ClickstreamProvider test', () => {
 				Event.ReservedAttribute.USER_FIRST_TOUCH_TIMESTAMP
 			].value
 		).toBe(userFirstTouchTimestamp);
+	});
+
+	test('test custom user attribute not in the subsequent event', async () => {
+		(provider.configuration as any).sendMode = SendMode.Batch;
+		provider.setUserId('123');
+		provider.setUserAttributes({
+			testAttribute: 'testValue',
+		});
+		provider.record({ name: 'testEvent' });
+		await sleep(100);
+		const eventList = JSON.parse(
+			StorageUtil.getAllEvents() + Event.Constants.SUFFIX
+		);
+		const lastEvent = eventList[eventList.length - 1];
+		expect(lastEvent.event_type).toBe('testEvent');
+		expect(lastEvent.user[Event.ReservedAttribute.USER_ID].value).toBe('123');
+		expect(lastEvent.user.testAttribute).toBeUndefined();
 	});
 
 	test('test add global attribute with invalid name', () => {

--- a/test/util/StorageUtil.test.ts
+++ b/test/util/StorageUtil.test.ts
@@ -34,7 +34,7 @@ describe('StorageUtil test', () => {
 	});
 
 	test('test get user Attributes return null object', () => {
-		const userAttribute = StorageUtil.getUserAttributes();
+		const userAttribute = StorageUtil.getAllUserAttributes();
 		expect(JSON.stringify(userAttribute)).toBe('{}');
 	});
 
@@ -42,7 +42,7 @@ describe('StorageUtil test', () => {
 		const userUniqueId = StorageUtil.getCurrentUserUniqueId();
 		expect(userUniqueId).not.toBeNull();
 		expect(userUniqueId.length > 0).toBeTruthy();
-		const userAttribute = StorageUtil.getUserAttributes();
+		const userAttribute = StorageUtil.getAllUserAttributes();
 		expect(userAttribute).not.toBeNull();
 		expect(Object.keys(userAttribute).length > 0).toBeTruthy();
 		expect(
@@ -68,9 +68,34 @@ describe('StorageUtil test', () => {
 				value: 'carl',
 			},
 		});
-		const userAttribute = StorageUtil.getUserAttributes();
+		const userAttribute = StorageUtil.getAllUserAttributes();
 		expect(Object.keys(userAttribute).length).toBe(2);
 		expect(userAttribute['userAge']['value']).toBe(18);
+	});
+
+	test('test get simple user attributes', () => {
+		const userId = Event.ReservedAttribute.USER_ID;
+		const firstTimestamp = Event.ReservedAttribute.USER_FIRST_TOUCH_TIMESTAMP;
+		const currentTimeStamp = new Date().getTime();
+		StorageUtil.updateUserAttributes({
+			[userId]: {
+				set_timestamp: currentTimeStamp,
+				value: 1234,
+			},
+			[firstTimestamp]: {
+				set_timestamp: currentTimeStamp,
+				value: currentTimeStamp,
+			},
+			userAge: {
+				set_timestamp: currentTimeStamp,
+				value: 18,
+			},
+		});
+		const simpleUserAttribute = StorageUtil.getSimpleUserAttributes();
+		expect(Object.keys(simpleUserAttribute).length).toBe(2);
+		expect(simpleUserAttribute[userId].value).toBe(1234);
+		expect(simpleUserAttribute[firstTimestamp].value).toBe(currentTimeStamp);
+		expect(simpleUserAttribute['userAge']).toBeUndefined();
 	});
 
 	test('test save and clear failed event', async () => {


### PR DESCRIPTION
## Description
1. delete custom user attributes from subsequent events

**NOTE: This is a breaking change, only pipelines from version 1.1+ can handle events without custom user attribute.**

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
