### PR TITLE
feat: add session attributes in _first_open event

### DIFF
--- a/src/tracker/SessionTracker.ts
+++ b/src/tracker/SessionTracker.ts
@@ -52,6 +52,7 @@ export class SessionTracker extends BaseTracker {
 	}
 
 	handleInit() {
+		this.session = Session.getCurrentSession(this.context);
 		if (StorageUtil.getIsFirstOpen()) {
 			this.provider.record({
 				name: Event.PresetEvent.FIRST_OPEN,
@@ -65,7 +66,6 @@ export class SessionTracker extends BaseTracker {
 		logger.debug('page appear');
 		const pageViewTracker = this.provider.pageViewTracker;
 		pageViewTracker.updateLastScreenStartTimestamp();
-		this.session = Session.getCurrentSession(this.context);
 		if (this.session.isNewSession()) {
 			pageViewTracker.setIsEntrances();
 			this.provider.record({ name: Event.PresetEvent.SESSION_START });

--- a/src/tracker/SessionTracker.ts
+++ b/src/tracker/SessionTracker.ts
@@ -66,6 +66,7 @@ export class SessionTracker extends BaseTracker {
 		logger.debug('page appear');
 		const pageViewTracker = this.provider.pageViewTracker;
 		pageViewTracker.updateLastScreenStartTimestamp();
+		this.session = Session.getCurrentSession(this.context);
 		if (this.session.isNewSession()) {
 			pageViewTracker.setIsEntrances();
 			this.provider.record({ name: Event.PresetEvent.SESSION_START });

--- a/test/ClickstreamAnalytics.test.ts
+++ b/test/ClickstreamAnalytics.test.ts
@@ -67,6 +67,10 @@ describe('ClickstreamAnalytics test', () => {
 		expect(firstEvent.user[Event.ReservedAttribute.USER_FIRST_TOUCH_TIMESTAMP]).not.toBeUndefined()
 		expect(firstEvent.attributes.brand).toBe('Samsung');
 		expect(firstEvent.attributes.level).toBe(10);
+		expect(firstEvent.attributes[Event.ReservedAttribute.SESSION_ID]).not.toBeUndefined();
+		expect(firstEvent.attributes[Event.ReservedAttribute.SESSION_NUMBER]).not.toBeUndefined();
+		expect(firstEvent.attributes[Event.ReservedAttribute.SESSION_START_TIMESTAMP]).not.toBeUndefined();
+		expect(firstEvent.attributes[Event.ReservedAttribute.SESSION_DURATION]).not.toBeUndefined();
 		const testEvent = eventList[eventList.length - 1];
 		expect(testEvent.attributes.brand).toBeUndefined();
 	});


### PR DESCRIPTION
## Description
1. add session attributes in _first_open event

## General Checklist
<!-- Check or cross out if not relevant -->

- [x] Added new tests to cover change, if needed
- [ ] Security oriented best practices and standards are followed (e.g. using input sanitization, principle of least privilege, etc)
- [ ] Documentation update for the change if required
- [x] PR title conforms to conventional commit style
- [ ] If breaking change, documentation/changelog update with migration instructions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
